### PR TITLE
Delete controller

### DIFF
--- a/server/src/controllers/activity/deleteActivity.js
+++ b/server/src/controllers/activity/deleteActivity.js
@@ -1,0 +1,17 @@
+import Activity from "../../models/Activity.js";
+import { logError } from "../../util/logging.js";
+
+export const deleteActivity = async (req, res) => {
+  const { activityID } = req.params;
+  try {
+    const activity = await Activity.findById(activityID);
+    if (!activity)
+      return res.status(404).json({ message: "Activity not found" });
+    //  triggers location delete
+    await activity.deleteOne();
+    res.json({ message: "Activity and its location deleted" });
+  } catch (err) {
+    res.status(500).json({ message: "server error" });
+    logError(err);
+  }
+};

--- a/server/src/controllers/activity/deleteActivity.js
+++ b/server/src/controllers/activity/deleteActivity.js
@@ -9,7 +9,7 @@ export const deleteActivity = async (req, res) => {
       return res.status(404).json({ message: "Activity not found" });
     //  triggers location delete
     await activity.deleteOne();
-    res.json({ message: "Activity and its location deleted" });
+    res.status(200).json({ message: "Activity and its location deleted" });
   } catch (err) {
     res.status(500).json({ message: "server error" });
     logError(err);

--- a/server/src/controllers/day/deleteDay.js
+++ b/server/src/controllers/day/deleteDay.js
@@ -8,7 +8,7 @@ export const deleteDay = async (req, res) => {
     if (!day) return res.status(404).json({ message: "Day not found" });
     // This triggers deleting its activities
     await day.deleteOne();
-    res.json({ message: "Day and related activities deleted" });
+    res.status(200).json({ message: "Day and related activities deleted" });
   } catch (err) {
     res.status(500).json({ message: "server error" });
     logError(err);

--- a/server/src/controllers/day/deleteDay.js
+++ b/server/src/controllers/day/deleteDay.js
@@ -1,0 +1,16 @@
+import Day from "../../models/Day.js";
+import { logError } from "../../util/logging.js";
+
+export const deleteDay = async (req, res) => {
+  const { dayID } = req.params;
+  try {
+    const day = await Day.findById(dayID);
+    if (!day) return res.status(404).json({ message: "Day not found" });
+    // This triggers deleting its activities
+    await day.deleteOne();
+    res.json({ message: "Day and related activities deleted" });
+  } catch (err) {
+    res.status(500).json({ message: "server error" });
+    logError(err);
+  }
+};

--- a/server/src/controllers/location/deleteLocation.js
+++ b/server/src/controllers/location/deleteLocation.js
@@ -11,7 +11,7 @@ export const deleteLocation = async (req, res) => {
 
     await location.deleteOne();
 
-    res.json({ message: "Location deleted successfully" });
+    res.status(200).json({ message: "Location deleted successfully" });
   } catch (err) {
     logError(err);
     res.status(500).json({ message: "Server error" });

--- a/server/src/controllers/location/deleteLocation.js
+++ b/server/src/controllers/location/deleteLocation.js
@@ -14,6 +14,6 @@ export const deleteLocation = async (req, res) => {
     res.status(200).json({ message: "Location deleted successfully" });
   } catch (err) {
     logError(err);
-    res.status(500).json({ message: "Server error" });
+    res.status(500).json({ message: "server error" });
   }
 };

--- a/server/src/controllers/location/deleteLocation.js
+++ b/server/src/controllers/location/deleteLocation.js
@@ -1,0 +1,19 @@
+import Location from "../../models/Location.js";
+import { logError } from "../../util/logging.js";
+export const deleteLocation = async (req, res) => {
+  const { locationID } = req.params;
+
+  try {
+    const location = await Location.findById(locationID);
+    if (!location) {
+      return res.status(404).json({ message: "Location not found" });
+    }
+
+    await location.deleteOne();
+
+    res.json({ message: "Location deleted successfully" });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ message: "Server error" });
+  }
+};

--- a/server/src/controllers/trip/deleteTrip.js
+++ b/server/src/controllers/trip/deleteTrip.js
@@ -1,0 +1,14 @@
+import Trip from "../../models/Trip";
+
+export const deleteTrip = async (req, res) => {
+  const tripID = req.params;
+  try {
+    const trip = await Trip.findById(tripID);
+    if (!trip) return res.status(404).json({ message: "Trip not found" });
+    // This triggers the cascading delete
+    await trip.deleteOne();
+    res.json({ message: "Trip and related data deleted" });
+  } catch (err) {
+    res.status(500).json({ message: "server error" });
+  }
+};

--- a/server/src/controllers/trip/deleteTrip.js
+++ b/server/src/controllers/trip/deleteTrip.js
@@ -8,7 +8,7 @@ export const deleteTrip = async (req, res) => {
     if (!trip) return res.status(404).json({ message: "Trip not found" });
     // This triggers the cascading delete
     await trip.deleteOne();
-    res.json({ message: "Trip and related data deleted" });
+    res.status(200).json({ message: "Trip and related data deleted" });
   } catch (err) {
     res.status(500).json({ message: "server error" });
     logError(err);

--- a/server/src/controllers/trip/deleteTrip.js
+++ b/server/src/controllers/trip/deleteTrip.js
@@ -1,7 +1,8 @@
-import Trip from "../../models/Trip";
+import Trip from "../../models/Trip.js";
+import { logError } from "../../util/logging.js";
 
 export const deleteTrip = async (req, res) => {
-  const tripID = req.params;
+  const { tripID } = req.params;
   try {
     const trip = await Trip.findById(tripID);
     if (!trip) return res.status(404).json({ message: "Trip not found" });
@@ -10,5 +11,6 @@ export const deleteTrip = async (req, res) => {
     res.json({ message: "Trip and related data deleted" });
   } catch (err) {
     res.status(500).json({ message: "server error" });
+    logError(err);
   }
 };

--- a/server/src/models/Activity.js
+++ b/server/src/models/Activity.js
@@ -1,5 +1,5 @@
 import mongoose from "mongoose";
-import Location from "./Location";
+import Location from "./Location.js";
 
 const activitySchema = new mongoose.Schema({
   name: {

--- a/server/src/models/Activity.js
+++ b/server/src/models/Activity.js
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import Location from "./Location";
 
 const activitySchema = new mongoose.Schema({
   name: {
@@ -25,7 +26,21 @@ const activitySchema = new mongoose.Schema({
     default: 0,
   },
 });
-
+// to delete the location that is related to the activity
+activitySchema.pre(
+  "deleteOne",
+  { document: true, query: false },
+  async function (next) {
+    try {
+      if (this.location) {
+        await Location.findByIdAndDelete(this.location);
+      }
+      next();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 const activity = mongoose.model("activities", activitySchema);
 
 export default activity;

--- a/server/src/models/Day.js
+++ b/server/src/models/Day.js
@@ -1,5 +1,5 @@
 import mongoose from "mongoose";
-import Activity from "./Activity";
+import Activity from "./Activity.js";
 
 const daySchema = new mongoose.Schema({
   title: {

--- a/server/src/models/Day.js
+++ b/server/src/models/Day.js
@@ -26,7 +26,10 @@ daySchema.pre(
   { document: true, query: false },
   async function (next) {
     try {
-      await Activity.deleteMany({ day: this._id });
+      const activities = await Activity.find({ day: this._id });
+      for (const activity of activities) {
+        await activity.deleteOne();
+      }
       next();
     } catch (err) {
       next(err);

--- a/server/src/models/Day.js
+++ b/server/src/models/Day.js
@@ -1,5 +1,7 @@
 import mongoose from "mongoose";
 import Activity from "./Activity.js";
+import Trip from "./Trip.js";
+import { logError } from "../util/logging.js";
 
 const daySchema = new mongoose.Schema({
   title: {
@@ -18,7 +20,7 @@ const daySchema = new mongoose.Schema({
     required: true,
   },
 });
-// to delete all activities related to that day
+// 1-to delete all activities related to that day
 daySchema.pre(
   "deleteOne",
   { document: true, query: false },
@@ -28,6 +30,27 @@ daySchema.pre(
       next();
     } catch (err) {
       next(err);
+    }
+  },
+);
+
+// 2-update the trip duration after the day is deleted
+daySchema.post(
+  "deleteOne",
+  { document: true, query: false },
+  async function () {
+    try {
+      const tripID = this.tripID;
+
+      // Count remaining days for the trip
+      const remainingDaysCount = await mongoose
+        .model("days")
+        .countDocuments({ tripID });
+
+      // Update the trip duration accordingly
+      await Trip.findByIdAndUpdate(tripID, { duration: remainingDaysCount });
+    } catch (err) {
+      logError(err);
     }
   },
 );

--- a/server/src/models/Day.js
+++ b/server/src/models/Day.js
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import Activity from "./Activity";
 
 const daySchema = new mongoose.Schema({
   title: {
@@ -17,7 +18,19 @@ const daySchema = new mongoose.Schema({
     required: true,
   },
 });
-
+// to delete all activities related to that day
+daySchema.pre(
+  "deleteOne",
+  { document: true, query: false },
+  async function (next) {
+    try {
+      await Activity.deleteMany({ day: this._id });
+      next();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 const day = mongoose.model("days", daySchema);
 
 export default day;

--- a/server/src/models/Trip.js
+++ b/server/src/models/Trip.js
@@ -62,7 +62,10 @@ tripSchema.pre(
   { document: true, query: false },
   async function (next) {
     try {
-      await Day.deleteMany({ tripID: this._id });
+      const days = await Day.find({ tripID: this._id });
+      for (const day of days) {
+        await day.deleteOne();
+      }
       next();
     } catch (err) {
       next(err);

--- a/server/src/models/Trip.js
+++ b/server/src/models/Trip.js
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import Day from "./Day.js";
 
 const tripSchema = new mongoose.Schema({
   // Basic Info
@@ -55,6 +56,19 @@ const tripSchema = new mongoose.Schema({
   },
 });
 
+// to delete all the days related to the trip
+tripSchema.pre(
+  "deleteOne",
+  { document: true, query: false },
+  async function (next) {
+    try {
+      await Day.deleteMany({ tripID: this._id });
+      next();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 const Trip = mongoose.model("trips", tripSchema);
 
 export default Trip;

--- a/server/src/routes/activityRoutes.js
+++ b/server/src/routes/activityRoutes.js
@@ -4,6 +4,7 @@ import { requireAuth } from "../middleware/requireAuth.js";
 import { createActivity } from "../controllers/activity/createActivity.js";
 import { validate } from "../middleware/validateData.js";
 import { createActivitySchema } from "../validation/schemas/activitySchemas.js";
+import { deleteActivity } from "../controllers/activity/deleteActivity.js";
 
 const activityRouter = express.Router({ mergeParams: true });
 
@@ -13,5 +14,6 @@ activityRouter.post(
   validate(createActivitySchema),
   createActivity,
 );
+activityRouter.delete("/:activityID", requireAuth, deleteActivity);
 
 export default activityRouter;

--- a/server/src/routes/dayRoutes.js
+++ b/server/src/routes/dayRoutes.js
@@ -4,6 +4,7 @@ import { createDay } from "../controllers/day/createDay.js";
 import { requireAuth } from "../middleware/requireAuth.js";
 import { validate } from "../middleware/validateData.js";
 import { createDaySchema } from "../validation/schemas/daysSchema.js";
+import { deleteDay } from "../controllers/day/deleteDay.js";
 
 const dayRouter = express.Router({ mergeParams: true });
 
@@ -13,5 +14,6 @@ dayRouter.post(
   validate(createDaySchema),
   createDay,
 );
+dayRouter.delete("/:dayID", requireAuth, deleteDay);
 
 export default dayRouter;

--- a/server/src/routes/locationRoutes.js
+++ b/server/src/routes/locationRoutes.js
@@ -3,6 +3,7 @@ import { createLocation } from "../controllers/location/createLocation.js";
 import { requireAuth } from "../middleware/requireAuth.js";
 import { validate } from "../middleware/validateData.js";
 import { createLocationSchema } from "../validation/schemas/locationSchemas.js";
+import { deleteLocation } from "../controllers/location/deleteLocation.js";
 
 const locationRouter = express.Router({ mergeParams: true });
 
@@ -12,5 +13,6 @@ locationRouter.post(
   validate(createLocationSchema),
   createLocation,
 );
+locationRouter.delete("/:locationID", requireAuth, deleteLocation);
 
 export default locationRouter;

--- a/server/src/routes/tripRoutes.js
+++ b/server/src/routes/tripRoutes.js
@@ -9,6 +9,7 @@ import {
 import { updateTrip } from "../controllers/trip/updateTrip.js";
 import { getTripById } from "../controllers/trip/getTripByID.js";
 import { toggleTripPublished } from "../controllers/trip/publishTrip.js";
+import { deleteTrip } from "../controllers/trip/deleteTrip.js";
 
 const tripRouter = express.Router();
 
@@ -26,5 +27,6 @@ tripRouter.post(
 );
 tripRouter.put("/publish/:tripID", requireAuth, toggleTripPublished);
 tripRouter.get("/:tripID", getTripById);
+tripRouter.delete("/:tripID", requireAuth, deleteTrip);
 
 export default tripRouter;


### PR DESCRIPTION
Added pre deleteOne middleware to Trip, Day, and Activity models to cascade deletions of related documents automatically. Created delete controllers for Trip, Day, Activity, and Location . Also added post deleteOne middleware on Day to update Trip duration after a Day is deleted. This ensures data consistency and cleaner removal of related data.
The delete cascade chain currently ends at Location, which is the last related collection for Trips. In the future, when adding more related data like images, corresponding cascade handling should be implemented.